### PR TITLE
Hide `call` and `CallSweepObject` because they don't work as expected

### DIFF
--- a/pytopo/sweep/__init__.py
+++ b/pytopo/sweep/__init__.py
@@ -1,3 +1,3 @@
-from .convenience import sweep, measure, time_trace, call, nest, chain, szip
+from .convenience import sweep, measure, time_trace, _call, nest, chain, szip
 from .decorators import getter, setter, hardsweep
 from .do_experiment import do_experiment

--- a/pytopo/sweep/base.py
+++ b/pytopo/sweep/base.py
@@ -215,7 +215,12 @@ class Measure(BaseSweepObject):
         yield self._get_function()
 
 
-class CallSweepObject(BaseSweepObject):
+class _CallSweepObject(BaseSweepObject):
+    """
+    ...
+
+    Note: this feature DOES NOT WORK at the moment.
+    """
     def __init__(self, call_function, *args, **kwargs):
         super().__init__()
         self._caller = lambda: call_function(*args, **kwargs)

--- a/pytopo/sweep/convenience.py
+++ b/pytopo/sweep/convenience.py
@@ -2,7 +2,7 @@ import time
 
 from qcodes import Parameter
 
-from pytopo.sweep.base import Sweep, Measure, Zip, CallSweepObject, Nest, Chain
+from pytopo.sweep.base import Sweep, Measure, Zip, _CallSweepObject, Nest, Chain
 
 from pytopo.sweep.decorators import (
     parameter_setter, parameter_getter, MeasureFunction, SweepFunction
@@ -71,8 +71,14 @@ def szip(*sweep_objects):
     return Zip(*sweep_objects)
 
 
-def call(call_function, *args, **kwargs):
-    return CallSweepObject(call_function, *args, **kwargs)
+# this does not work at the moment, see tests
+def _call(call_function, *args, **kwargs):
+    """
+    ...
+
+    Note: this feature DOES NOT WORK at the moment.
+    """
+    return _CallSweepObject(call_function, *args, **kwargs)
 
 
 def nest(*sweep_objects):

--- a/pytopo/sweep/tests/test_convenience.py
+++ b/pytopo/sweep/tests/test_convenience.py
@@ -1,8 +1,10 @@
+import numpy
 import pytest
 
 from qcodes import Parameter
 
-from pytopo.sweep.convenience import sweep, measure
+from pytopo.sweep.base import _CallSweepObject
+from pytopo.sweep.convenience import sweep, measure, _call, nest, chain
 from pytopo.sweep.decorators import getter, setter
 
 from ._test_tools import Factory
@@ -100,3 +102,132 @@ def test_error():
 
     with pytest.raises(ValueError):
         sweep(no_good_setter, [0, 1])
+
+
+def test_sanity_call():
+    var = 2
+    def increment_var_by(num):
+        nonlocal var
+        var = var + num
+
+    so = _call(increment_var_by, 3)
+
+    assert isinstance(so, _CallSweepObject)
+    assert False == so.has_chain
+    assert False == so.measurable
+    assert [[]] == so.parameter_table.nests
+    assert [] == so.parameter_table.param_specs
+
+    sweep_output = list(so)
+    assert [{}] == sweep_output
+
+    assert 5 == var
+
+
+def test_call_inside_sweep(parameters):
+    p = parameters["p"]
+    values = [0, 1, 2]
+
+    var = 2
+    def increment_var_by(num):
+        nonlocal var
+        var = var + num
+
+    so = sweep(p, values)(
+        _call(increment_var_by, 3)
+    )
+
+    sweep_output = list(so)
+
+    assert sweep_output == [{"p": value} for value in values]
+    assert 2 + 3*len(values) == var
+
+
+def test_call_inside_sweep_and_chain(parameters):
+    p = parameters["p"]
+    values = [0, 1, 2]
+
+    var = 2
+    def increment_var_by(num):
+        nonlocal var
+        var = var + num
+
+    @getter(('q', ''))
+    def measure_function():
+        nonlocal var
+        return var
+
+    so = nest(sweep(p, values),
+              chain(
+                  measure(measure_function),
+                  _call(increment_var_by, 3)
+              )
+              )
+
+    sweep_output = list(so)
+
+    assert 2 + 3 * len(values) == var
+
+    # `call` should work like this:
+    # assert sweep_output == [{"p": p_val, 'q': q_val}
+    #                         for p_val, q_val
+    #                         in zip(values,
+    #                                2+3*numpy.array(range(len(values)))
+    #                                )
+    #                         ]
+
+    # instead it works like this:
+    # (basically, for every call of 'call' there is an extra dictionary
+    # without the second parameter value)
+    assert sweep_output == [item for sublist in
+        [[{"p": p_val, 'q': q_val}, {"p": p_val}]
+         for p_val, q_val
+         in zip(values, 2 + 3 * numpy.array(range(len(values))))
+         ]
+        for item in sublist]
+
+
+def test_call_inside_sweep_and_chain_2(parameters):
+    p = parameters["p"]
+    values = [0, 1, 2]
+
+    var = 2
+    def increment_var_by(num):
+        nonlocal var
+        var = var + num
+
+    @getter(('q', ''))
+    def measure_function():
+        nonlocal var
+        return var
+
+    @getter(('v', ''))
+    def measure_function_2():
+        nonlocal var
+        return var + 1
+
+    so = sweep(p, values)(
+        measure(measure_function),
+        _call(increment_var_by, 3),
+        measure(measure_function_2),
+    )
+
+    sweep_output = list(so)
+
+    assert 2 + 3 * len(values) == var
+
+    # `call` should work like this:
+    # assert sweep_output == [{"p": p_val, 'q': q_val, 'v': v_val}
+    #                         for p_val, q_val, v_val
+    #                         in zip(values,
+    #                                2+3*numpy.array(range(len(values))),
+    #                                2+3*numpy.array(range(len(values)))+1
+    #                                )
+    #                         ]
+
+    # instead it works like this:
+    # (basically, there are extra dictionaries without values of some of the
+    # parameters that are involved in a sweep object, and more weird stuff...)
+    assert sweep_output == [{'q': 2, 'p': 0}, {'p': 0}, {'v': 6, 'p': 0},
+                            {'q': 5, 'p': 1}, {'p': 1}, {'v': 9, 'p': 1},
+                            {'q': 8, 'p': 2}, {'p': 2}, {'v': 12, 'p': 2}]


### PR DESCRIPTION
also cover their behavior with tests.

this will be fixed later....