### PR TITLE
Set track number in awg sequence to channel number

### DIFF
--- a/pytopo/awg_sequencing/broadbean.py
+++ b/pytopo/awg_sequencing/broadbean.py
@@ -212,7 +212,7 @@ class BroadBeanSequence():
                 for ch_no, ch_desc in self.chan_map.items():
                     chan = self.awg.channels[ch_no-1]
 
-                    track_number = 1
+                    track_number = ch_no
                     chan.setSequenceTrack(seq.name, track_number)
 
                     chan.resolution(12)


### PR DESCRIPTION
This is so far the only outcome of Luca working with BluePrints which is the convenience over broadbean. We'll see if this moves forward or will just be it.

So, this PR fixes this small bug (aparrently it's a bug).

@wpfff could you comment on this minor change? )