### PR TITLE
Sweep: use public qcodes api to register parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,58 @@
-.vscode
-.ipynb_checkpoints
 *.pyc
 labpythonconfig.py
 *.db
 *.dat
 *.png
 *.pdf
-pytopo.egg-info
-.idea
+
+# Byte-compiled / optimized / DLL files
 __pycache__/
-.mypy_cache/
+*.py[cod]
+
+# .pyenv file
+.python-version
+
+# ipython extras
+.ipynb_checkpoints/
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+.pytest_cache/*
+
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis
+
+# Temporary files
+*.md~
+*.py~
+.mypy_cache/*
+
+.idea/
+.vscode/
+
+# Mac files
+.DS_Store

--- a/pytopo/sweep/decorators.py
+++ b/pytopo/sweep/decorators.py
@@ -2,10 +2,10 @@ import numpy as np
 
 from typing import List, Iterable, Tuple, Callable, Any
 
-from qcodes import ParamSpec
 from pytopo.sweep import param_table
 from pytopo.sweep.param_table import ParamTable
 from pytopo.sweep.base import IteratorSweep
+from .param_spec import QcodesParamSpec as ParamSpec
 
 
 class _GetterSetterFunction:
@@ -42,7 +42,7 @@ def _generate_tables(names_units: Iterable[Tuple]) ->List[ParamTable]:
             Example: [("gate", "V"), ("Isd", "A", "array")]
 
     Returns:
-        A list of ParamTable with each table containing a single ParamSpec
+        A list of ParamTable with each table containing a single QcodesParamSpec
     """
     param_tables = []
 

--- a/pytopo/sweep/measurement.py
+++ b/pytopo/sweep/measurement.py
@@ -8,6 +8,16 @@ class SweepMeasurement(Measurement):
         sweep_object.parameter_table.resolve_dependencies()
         param_specs = sweep_object.parameter_table.param_specs
 
-        self.parameters = {
-            p.name: p for p in param_specs
-        }
+        # We sort by the length of `depends_on_` of ParamSpec so that 
+        # standalone parameters are registered first
+        param_specs_sorted = sorted(param_specs,
+                                    key=lambda p: len(p.depends_on_))
+
+        for p in param_specs_sorted:
+            self.register_custom_parameter(
+                name=p.name,
+                label=p.label,
+                unit=p.unit,
+                basis=p.inferred_from_,
+                setpoints=p.depends_on_,
+                paramtype=p.type)

--- a/pytopo/sweep/param_spec.py
+++ b/pytopo/sweep/param_spec.py
@@ -1,0 +1,184 @@
+"""
+This module is taken from QCoDeS and contains old ParamSpec class
+(here renamed to QcodesParamSpec) that is used in sweep framework 
+in ParamTables. QCoDeS will soon deprecate ParamSpec in favor of 
+ParamSpecBase.
+
+Copy-pasting code is not good, but it allows to future-proof sweep
+framework users with very little effort.
+"""
+
+from typing import Union, Sequence, List, Dict, Any, Optional
+from copy import deepcopy
+
+from qcodes.dataset.param_spec import ParamSpecBase
+
+
+class QcodesParamSpec():
+
+    allowed_types = ['array', 'numeric', 'text', 'complex']
+
+    def __init__(self, name: str,
+                 paramtype: str,
+                 label: Optional[str] = None,
+                 unit: Optional[str] = None,
+                 inferred_from: Sequence[Union['QcodesParamSpec', str]] = None,
+                 depends_on: Sequence[Union['QcodesParamSpec', str]] = None,
+                 **metadata) -> None:
+        """
+        Args:
+            name: name of the parameter
+            paramtype: type of the parameter, i.e. the SQL storage class
+            label: label of the parameter
+            inferred_from: the parameters that this parameter is inferred from
+            depends_on: the parameters that this parameter depends on
+        """
+
+        if not isinstance(paramtype, str):
+            raise ValueError('Paramtype must be a string.')
+        if paramtype.lower() not in self.allowed_types:
+            raise ValueError("Illegal paramtype. Must be on of "
+                             f"{self.allowed_types}")
+        if not name.isidentifier():
+            raise ValueError(f'Invalid name: {name}. Only valid python '
+                             'identifier names are allowed (no spaces or '
+                             'punctuation marks, no prepended '
+                             'numbers, etc.)')
+
+        self.name = name
+        self.type = paramtype.lower()
+        self.label = label or ''
+        self.unit = unit or ''
+
+        self._inferred_from: List[str] = []
+        self._depends_on: List[str] = []
+
+        inferred_from = [] if inferred_from is None else inferred_from
+        depends_on = [] if depends_on is None else depends_on
+
+        if isinstance(inferred_from, str):
+            raise ValueError(f"QcodesParamSpec {self.name} got "
+                             f"string {inferred_from} as inferred_from. "
+                             f"It needs a "
+                             f"Sequence of QcodesParamSpecs or strings")
+        self._inferred_from.extend(
+            p.name if isinstance(p, QcodesParamSpec) else p
+            for p in inferred_from)
+
+        if isinstance(depends_on, str):
+            raise ValueError(f"QcodesParamSpec {self.name} got "
+                             f"string {depends_on} as depends_on. It needs a "
+                             f"Sequence of QcodesParamSpecs or strings")
+        self._depends_on.extend(
+            p.name if isinstance(p, QcodesParamSpec) else p
+            for p in depends_on)
+
+        if metadata:
+            self.metadata = metadata
+
+    @property
+    def inferred_from_(self) -> List[str]:
+        return deepcopy(self._inferred_from)
+
+    @property
+    def depends_on_(self) -> List[str]:
+        return deepcopy(self._depends_on)
+
+    @property
+    def inferred_from(self) -> str:
+        return ', '.join(self._inferred_from)
+
+    @property
+    def depends_on(self) -> str:
+        return ', '.join(self._depends_on)
+
+    def copy(self) -> 'QcodesParamSpec':
+        """
+        Make a copy of self
+        """
+        return QcodesParamSpec(self.name, self.type, self.label, self.unit,
+                         deepcopy(self._inferred_from),
+                         deepcopy(self._depends_on))
+
+    def sql_repr(self):
+        return f"{self.name} {self.type}"
+
+    def __repr__(self):
+        return (f"QcodesParamSpec('{self.name}', '{self.type}', '{self.label}', "
+                f"'{self.unit}', inferred_from={self._inferred_from}, "
+                f"depends_on={self._depends_on})")
+
+    def __eq__(self, other):
+        if not isinstance(other, QcodesParamSpec):
+            return False
+        string_attrs = ['name', 'type', 'label', 'unit']
+        list_attrs = ['_inferred_from', '_depends_on']
+        for string_attr in string_attrs:
+            if getattr(self, string_attr) != getattr(other, string_attr):
+                return False
+        for list_attr in list_attrs:
+            ours = getattr(self, list_attr)
+            theirs = getattr(other, list_attr)
+            if ours != theirs:
+                return False
+        return True
+
+    def __hash__(self) -> int:
+        """Allow QcodesParamSpecs in data structures that use hashing (i.e. sets)"""
+        attrs_with_strings = ['name', 'type', 'label', 'unit']
+        attrs_with_lists = ['_inferred_from', '_depends_on']
+
+        # First, get the hash of the tuple with all the relevant attributes
+        all_attr_tuple_hash = hash(
+            tuple(getattr(self, attr) for attr in attrs_with_strings)
+            + tuple(tuple(getattr(self, attr)) for attr in attrs_with_lists)
+        )
+        hash_value = all_attr_tuple_hash
+
+        # Then, XOR it with the individual hashes of all relevant attributes
+        for attr in attrs_with_strings:
+            hash_value = hash_value ^ hash(getattr(self, attr))
+        for attr in attrs_with_lists:
+            hash_value = hash_value ^ hash(tuple(getattr(self, attr)))
+
+        return hash_value
+
+    def serialize(self) -> Dict[str, Any]:
+        """
+        Write the QcodesParamSpec as a dictionary
+        """
+        output: Dict[str, Any] = {}
+        output['name'] = self.name
+        output['paramtype'] = self.type
+        output['label'] = self.label
+        output['unit'] = self.unit
+        output['inferred_from'] = self._inferred_from
+        output['depends_on'] = self._depends_on
+
+        return output
+
+    def base_version(self) -> ParamSpecBase:
+        """
+        Return a ParamSpecBase object with the same name, paramtype, label
+        and unit as this QcodesParamSpec
+        """
+        return ParamSpecBase(name=self.name,
+                             paramtype=self.type,
+                             label=self.label,
+                             unit=self.unit)
+
+    @classmethod
+    def deserialize(cls, ser: Dict[str, Any]) -> 'QcodesParamSpec':
+        """
+        Create a QcodesParamSpec instance of the current version
+        from a serialized QcodesParamSpec of some version
+
+        The version changes must be implemented as a series of transformations
+        of the serialized dict.
+        """
+        return QcodesParamSpec(name=ser['name'],
+                         paramtype=ser['paramtype'],
+                         label=ser['label'],
+                         unit=ser['unit'],
+                         inferred_from=ser['inferred_from'],
+                         depends_on=ser['depends_on'])

--- a/pytopo/sweep/param_table.py
+++ b/pytopo/sweep/param_table.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 from typing import List
-from qcodes import ParamSpec
+
+from .param_spec import QcodesParamSpec as ParamSpec
 
 
 class ParamTable:

--- a/pytopo/sweep/tests/test_base.py
+++ b/pytopo/sweep/tests/test_base.py
@@ -1,10 +1,10 @@
 import itertools
 import pytest
 
-from qcodes import Parameter, ParamSpec
+from qcodes import Parameter
 from pytopo.sweep.base import Sweep, Measure, Nest, Chain
 from pytopo.sweep.param_table import ParamTable
-
+from ..param_spec import QcodesParamSpec as ParamSpec
 from ._test_tools import Factory
 
 

--- a/pytopo/sweep/tests/test_param_table.py
+++ b/pytopo/sweep/tests/test_param_table.py
@@ -76,7 +76,7 @@ def test_inferred_from():
     a = ParamSpec("a", paramtype="numeric")
     b = ParamSpec("b", paramtype="numeric")
     c = ParamSpec("c", paramtype="numeric")
-    d = ParamSpec("d", paramtype="numeric", inferred_from='c')
+    d = ParamSpec("d", paramtype="numeric", inferred_from=['c'])
 
     table_a = ParamTable([a])
     table_b = ParamTable([b])

--- a/pytopo/sweep/tests/test_param_table.py
+++ b/pytopo/sweep/tests/test_param_table.py
@@ -1,5 +1,5 @@
-from qcodes import ParamSpec
 from pytopo.sweep.base import ParamTable
+from ..param_spec import QcodesParamSpec as ParamSpec
 
 
 def test_nest():

--- a/pytopo/sweep/tests/test_paramspec.py
+++ b/pytopo/sweep/tests/test_paramspec.py
@@ -1,0 +1,303 @@
+from keyword import iskeyword
+from numbers import Number
+
+import pytest
+from numpy import ndarray
+from hypothesis import given, assume
+import hypothesis.strategies as hst
+
+from qcodes.dataset.param_spec import ParamSpecBase
+
+from ..param_spec import QcodesParamSpec as ParamSpec
+
+
+def valid_identifier(**kwargs):
+    """Return a strategy which generates a valid Python Identifier"""
+    if 'min_size' not in kwargs:
+        kwargs['min_size'] = 4
+    return hst.text(
+        alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_",
+        **kwargs).filter(
+        lambda x: x[0].isalpha() and x.isidentifier() and not (iskeyword(x))
+    )
+
+
+# This strategy generates a dict of kwargs needed to instantiate a valid
+# ParamSpec object
+valid_paramspec_kwargs = hst.fixed_dictionaries(
+    {'name': valid_identifier(min_size=1, max_size=6),
+     'paramtype': hst.sampled_from(['numeric', 'array', 'text']),
+     'label': hst.one_of(hst.none(), hst.text(min_size=0, max_size=6)),
+     'unit': hst.one_of(hst.none(), hst.text(min_size=0, max_size=2)),
+     'depends_on': hst.lists(hst.text(min_size=1, max_size=3),
+                             min_size=0, max_size=3),
+     'inferred_from': hst.lists(hst.text(min_size=1, max_size=3),
+                                min_size=0, max_size=3)
+     })
+
+
+@pytest.fixture
+def version_0_serializations():
+    sers = []
+    sers.append({'name': 'dmm_v1',
+                 'paramtype': 'numeric',
+                 'label': 'Gate v1',
+                 'unit': 'V',
+                 'inferred_from': [],
+                 'depends_on': ['dac_ch1', 'dac_ch2']})
+    sers.append({'name': 'some_name',
+                 'paramtype': 'array',
+                 'label': 'My Array ParamSpec',
+                 'unit': 'Ars',
+                 'inferred_from': ['p1', 'p2'],
+                 'depends_on': []})
+    return sers
+
+
+@pytest.fixture
+def version_0_deserializations():
+    """
+    The paramspecs that the above serializations should deserialize to
+    """
+    ps = []
+    ps.append(ParamSpec('dmm_v1', paramtype='numeric', label='Gate v1',
+                        unit='V', inferred_from=[],
+                        depends_on=['dac_ch1', 'dac_ch2']))
+    ps.append(ParamSpec('some_name', paramtype='array',
+                        label='My Array ParamSpec', unit='Ars',
+                        inferred_from=['p1', 'p2'], depends_on=[]))
+    return ps
+
+
+@given(name=hst.text(min_size=1),
+       sp1=hst.text(min_size=1), sp2=hst.text(min_size=1),
+       inff1=hst.text(min_size=1), inff2=hst.text(min_size=1),
+       paramtype=hst.lists(
+           elements=hst.sampled_from(['numeric', 'array', 'text']),
+           min_size=6, max_size=6))
+def test_creation(name, sp1, sp2, inff1, inff2, paramtype):
+    invalid_types = ['np.array', 'ndarray', 'lala', '', Number,
+                     ndarray, 0, None]
+    for inv_type in invalid_types:
+        with pytest.raises(ValueError):
+            ParamSpec(name, inv_type)
+
+    if not inff1.isidentifier():
+        inff1 = 'inff1'
+
+    if not sp1.isidentifier():
+        sp1 = 'sp1'
+
+    if not name.isidentifier():
+        with pytest.raises(ValueError):
+            ps = ParamSpec(name, paramtype[0], label=None, unit='V',
+                           inferred_from=(inff1, inff2),
+                           depends_on=(sp1, sp2))
+        name = 'name'
+
+    ps = ParamSpec(name, paramtype[1], label=None, unit='V',
+                   inferred_from=(inff1, inff2),
+                   depends_on=(sp1, sp2))
+
+    assert ps.inferred_from == f'{inff1}, {inff2}'
+    assert ps.depends_on == f'{sp1}, {sp2}'
+
+    ps1 = ParamSpec(sp1, paramtype[2])
+    p1 = ParamSpec(name, paramtype[3], depends_on=(ps1, sp2))
+    assert p1.depends_on == ps.depends_on
+
+    ps2 = ParamSpec(inff1, paramtype[4])
+    p2 = ParamSpec(name, paramtype[5], inferred_from=(ps2, inff2))
+    assert p2.inferred_from == ps.inferred_from
+
+
+@given(name=hst.text(min_size=1))
+def test_repr(name):
+    okay_types = ['array', 'numeric', 'text']
+
+    for okt in okay_types:
+        if name.isidentifier():
+            ps = ParamSpec(name, okt)
+            expected_repr = (f"QcodesParamSpec('{name}', '{okt}', '', '', "
+                             "inferred_from=[], depends_on=[])")
+            assert ps.__repr__() == expected_repr
+        else:
+            with pytest.raises(ValueError):
+                ps = ParamSpec(name, okt)
+
+
+alphabet = "".join([chr(i) for i in range(ord("a"), ord("z"))])
+
+
+@given(
+    name1=hst.text(min_size=4, alphabet=alphabet),
+    name2=hst.text(min_size=4, alphabet=alphabet),
+    name3=hst.text(min_size=4, alphabet=alphabet)
+)
+def test_depends_on(name1, name2, name3):
+    ps2 = ParamSpec(name2, "numeric")
+    ps3 = ParamSpec(name3, "numeric")
+
+    ps1 = ParamSpec(name1, "numeric", depends_on=[ps2, ps3, 'foo'])
+
+    assert ps1.depends_on == f"{ps2.name}, {ps3.name}, foo"
+    assert ps1.depends_on_ == [ps2.name, ps3.name, "foo"]
+
+    with pytest.raises(ValueError,
+                       match=f"ParamSpec {name1} got string foo as depends_on. "
+                       "It needs a Sequence of QcodesParamSpecs or strings"):
+        ParamSpec(name1, "numeric", depends_on='foo')
+
+
+@given(
+    name1=hst.text(min_size=4, alphabet=alphabet),
+    name2=hst.text(min_size=4, alphabet=alphabet),
+    name3=hst.text(min_size=4, alphabet=alphabet)
+)
+def test_inferred_from(name1, name2, name3):
+    ps2 = ParamSpec(name2, "numeric")
+    ps3 = ParamSpec(name3, "numeric")
+
+    ps1 = ParamSpec(name1, "numeric", inferred_from=[ps2, ps3, 'bar'])
+
+    assert ps1.inferred_from == f"{ps2.name}, {ps3.name}, bar"
+    assert ps1.inferred_from_ == [ps2.name, ps3.name, "bar"]
+
+    with pytest.raises(ValueError,
+                       match=f"ParamSpec {name1} got string foo as "
+                       f"inferred_from. "
+                       "It needs a Sequence of QcodesParamSpecs or strings"):
+        ParamSpec(name1, "numeric", inferred_from='foo')
+
+
+@given(
+    name1=hst.text(min_size=4, alphabet=alphabet),
+    name2=hst.text(min_size=4, alphabet=alphabet)
+)
+def test_copy(name1, name2):
+    ps_indep = ParamSpec(name1, "numeric")
+    ps = ParamSpec(name2, "numeric", depends_on=[ps_indep, 'other_param'])
+    ps_copy = ps.copy()
+
+    assert ps_copy == ps
+    assert hash(ps_copy) == hash(ps)
+
+    att_names = ["name", "type", "label", "unit",
+                 "_inferred_from", "_depends_on"]
+
+    attributes = {}
+    for att in att_names:
+        val = getattr(ps, att)
+        valc = getattr(ps_copy, att)
+        assert val == valc
+        attributes[att] = val
+
+    # Modifying the copy should not change the original
+    for att in att_names:
+        if not att.startswith('_'):
+            setattr(ps_copy, att, attributes[att] + "_modified")
+        else:
+            setattr(ps_copy, att, attributes[att] + ['bob'])
+        assert getattr(ps, att) == attributes[att]
+
+    assert ps_copy != ps
+    assert hash(ps_copy) != hash(ps)
+
+
+def test_serialize():
+    p1 = ParamSpec('p1', 'numeric', 'paramspec one', 'no unit',
+                   depends_on=['some', 'thing'], inferred_from=['bab', 'bob'])
+
+    ser = p1.serialize()
+
+    assert ser['name'] == p1.name
+    assert ser['paramtype'] == p1.type
+    assert ser['label'] == p1.label
+    assert ser['unit'] == p1.unit
+    assert ser['depends_on'] == p1._depends_on
+    assert ser['inferred_from'] == p1._inferred_from
+
+
+def test_deserialize(version_0_serializations, version_0_deserializations):
+    for sdict, ps in zip(version_0_serializations, version_0_deserializations):
+        deps = ParamSpec.deserialize(sdict)
+        assert ps == deps
+
+
+@given(paramspecs=hst.lists(valid_paramspec_kwargs, min_size=2, max_size=2))
+def test_hash(paramspecs):
+    p1 = ParamSpec(**paramspecs[0])
+    p2 = ParamSpec(**paramspecs[1])
+
+    # call __hash__
+    p1_h = hash(p1)
+    p2_h = hash(p2)
+
+    # make a set
+    p_set = {p1, p2}
+
+    # test that the hash equality follows object equality
+    if p1 == p2:
+        assert p1_h == p2_h
+        assert 1 == len(p_set)
+    else:
+        assert p1_h != p2_h
+        assert 2 == len(p_set)
+
+
+@given(paramspecs=hst.lists(valid_paramspec_kwargs, min_size=6, max_size=6),
+       add_to_1_inf=hst.booleans(),
+       add_to_1_dep=hst.booleans(),
+       add_to_2_inf=hst.booleans(),
+       add_to_2_dep=hst.booleans(),
+       )
+def test_hash_with_deferred_and_inferred_as_paramspecs(
+        paramspecs, add_to_1_inf, add_to_1_dep, add_to_2_inf, add_to_2_dep):
+    """
+    Test that hashing works if 'inferred_from' and/or 'depends_on' contain
+    actual ParamSpec instances and not just strings.
+    """
+    assume(add_to_1_inf or add_to_1_dep or add_to_2_inf or add_to_2_dep)
+
+    # Add ParamSpecs to 'inferred_from' and/or 'depend_on' lists next to
+    # strings (that are generated by the main strategy)
+    if add_to_1_inf:
+        paramspecs[0]['inferred_from'].append(ParamSpec(**paramspecs[2]))
+    if add_to_1_dep:
+        paramspecs[0]['depends_on'].append(ParamSpec(**paramspecs[3]))
+    if add_to_2_inf:
+        paramspecs[1]['inferred_from'].append(ParamSpec(**paramspecs[4]))
+    if add_to_2_dep:
+        paramspecs[1]['depends_on'].append(ParamSpec(**paramspecs[5]))
+
+    p1 = ParamSpec(**paramspecs[0])
+    p2 = ParamSpec(**paramspecs[1])
+
+    # call __hash__
+    p1_h = hash(p1)
+    p2_h = hash(p2)
+
+    # make a set
+    p_set = {p1, p2}
+
+    # test that the hash equality follows object equality
+    if p1 == p2:
+        assert p1_h == p2_h
+        assert 1 == len(p_set)
+    else:
+        assert p1_h != p2_h
+        assert 2 == len(p_set)
+
+
+@given(paramspecs=hst.lists(valid_paramspec_kwargs, min_size=1, max_size=1))
+def test_base_version(paramspecs):
+
+    kwargs = paramspecs[0]
+
+    ps = ParamSpec(**kwargs)
+    ps_base = ParamSpecBase(name=kwargs['name'],
+                            paramtype=kwargs['paramtype'],
+                            label=kwargs['label'],
+                            unit=kwargs['unit'])
+
+    assert ps.base_version() == ps_base

--- a/pytopo/sweep/tests/test_sweep_measurement.py
+++ b/pytopo/sweep/tests/test_sweep_measurement.py
@@ -1,0 +1,242 @@
+"""
+This is mostly copy-paste of test_base but the test cases are user to
+test correct registering of parameters in SweepMeasurement.
+"""
+from qcodes.dataset.param_spec import ParamSpecBase
+
+from pytopo.sweep.measurement import SweepMeasurement
+from pytopo.sweep.base import Sweep, Measure, Nest, Chain
+
+from .test_base import indep_params, dep_params
+
+
+def test_sweep_parameter(indep_params):
+
+    px, x, table = indep_params["x"]
+
+    sweep_values = [0, 1, 2]
+    parameter_sweep = Sweep(x, table, lambda: sweep_values)
+
+    meas = SweepMeasurement()
+    meas.register_sweep(parameter_sweep)
+
+    interdeps = meas._interdeps
+    assert interdeps.dependencies == {}
+    assert interdeps.inferences == {}
+    assert interdeps.standalones == {ParamSpecBase('x', 'numeric', '', '')}
+
+
+def test_nest(indep_params, dep_params):
+    px, x, tablex = indep_params["x"]
+    pi, i, tablei = dep_params["i"]
+
+    def f(value): return value**2
+
+    pi.get = lambda: f(px())
+
+    sweep_values = [0, 1, 2]
+
+    nest = Nest(
+        Sweep(x, tablex, lambda: sweep_values),
+        Measure(i, tablei)
+    )
+
+    meas = SweepMeasurement()
+    meas.register_sweep(nest)
+
+    interdeps = meas._interdeps
+    assert interdeps.dependencies == {
+        ParamSpecBase('i', 'numeric', '', ''): (ParamSpecBase('x', 'numeric', '', ''),)}
+    assert interdeps.inferences == {}
+    assert interdeps.standalones == set()
+
+
+def test_nest_2d(indep_params, dep_params):
+    px, x, tablex = indep_params["x"]
+    py, y, tabley = indep_params["y"]
+
+    def f(vx, vy): return vx**2 + vy**2
+
+    pi, i, tablei = dep_params["i"]
+    pi.get = lambda: f(px(), py())
+
+    sweep_values_x = [0, 1, 2]
+    sweep_values_y = [5, 6, 7]
+
+    nest = Nest(
+        Sweep(x, tablex, lambda: sweep_values_x),
+        Sweep(y, tabley, lambda: sweep_values_y),
+        Measure(i, tablei)
+    )
+
+    meas = SweepMeasurement()
+    meas.register_sweep(nest)
+
+    interdeps = meas._interdeps
+    assert interdeps.dependencies == {
+        ParamSpecBase('i', 'numeric', '', ''): (ParamSpecBase('x', 'numeric', '', ''), ParamSpecBase('y', 'numeric', '', ''))}
+    assert interdeps.inferences == {}
+    assert interdeps.standalones == set()
+
+
+
+def test_nest_3d(indep_params, dep_params):
+    px, x, tablex = indep_params["x"]
+    py, y, tabley = indep_params["y"]
+    pz, z, tablez = indep_params["z"]
+
+    def f(vx, vy, vz): return vx**2 + vy**2 + vz**2
+
+    pi, i, tablei = dep_params["i"]
+    pi.get = lambda: f(px(), py(), pz())
+
+    sweep_values_x = [0, 1, 2]
+    sweep_values_y = [5, 6, 7]
+    sweep_values_z = [8, 9, 10]
+
+    nest = Nest(
+        Sweep(x, tablex, lambda: sweep_values_x),
+        Sweep(y, tabley, lambda: sweep_values_y),
+        Sweep(z, tablez, lambda: sweep_values_z),
+        Measure(i, tablei)
+    )
+
+    meas = SweepMeasurement()
+    meas.register_sweep(nest)
+
+    interdeps = meas._interdeps
+    assert interdeps.dependencies == {
+        ParamSpecBase('i', 'numeric', '', ''): (ParamSpecBase('x', 'numeric', '', ''), ParamSpecBase('y', 'numeric', '', ''), ParamSpecBase('z', 'numeric', '', ''))}
+    assert interdeps.inferences == {}
+    assert interdeps.standalones == set()
+
+
+def test_chain_simple(indep_params):
+    px, x, tablex = indep_params["x"]
+    py, y, tabley = indep_params["y"]
+
+    sweep_values_x = [0, 1, 2]
+    sweep_values_y = [4, 5, 6]
+
+    parameter_sweep = Chain(
+        Sweep(x, tablex, lambda: sweep_values_x),
+        Sweep(y, tabley, lambda: sweep_values_y)
+    )
+
+    meas = SweepMeasurement()
+    meas.register_sweep(parameter_sweep)
+
+    interdeps = meas._interdeps
+    assert interdeps.dependencies == {}
+    assert interdeps.inferences == {}
+    assert interdeps.standalones == {
+        ParamSpecBase('y', 'numeric', '', ''), ParamSpecBase('x', 'numeric', '', '')}
+
+
+def test_nest_chain(indep_params, dep_params):
+    px, x, tablex = indep_params["x"]
+    py, y, tabley = indep_params["y"]
+
+    pi, i, tablei = dep_params["i"]
+    pj, j, tablej = dep_params["j"]
+
+    def f(vx, vy):
+        return vx**2 + vy**3
+
+    pi.get = lambda: f(px(), py())
+
+    def g(vx, vy):
+        return vx**2 + vy**2
+
+    pj.get = lambda: g(px(), py())
+
+    sweep_values_x = [0, 1, 2]
+    sweep_values_y = [4, 5, 6]
+
+    sweep_object = Nest(
+        Sweep(x, tablex, lambda: sweep_values_x),
+        Sweep(y, tabley, lambda: sweep_values_y),
+        Chain(
+            Measure(i, tablei),
+            Measure(j, tablej)
+        )
+    )
+
+    meas = SweepMeasurement()
+    meas.register_sweep(sweep_object)
+
+    interdeps = meas._interdeps
+    assert interdeps.dependencies == {
+        ParamSpecBase('i', 'numeric', '', ''): (ParamSpecBase('x', 'numeric', '', ''),
+                                                ParamSpecBase('y', 'numeric', '', '')),
+        ParamSpecBase('j', 'numeric', '', ''): (ParamSpecBase('x', 'numeric', '', ''),
+                                                ParamSpecBase('y', 'numeric', '', ''))}
+    assert interdeps.inferences == {}
+    assert interdeps.standalones == set()
+
+
+def test_interleave_1d_2d(indep_params, dep_params):
+    px, x, tablex = indep_params["x"]
+    py, y, tabley = indep_params["y"]
+
+    pi, i, tablei = dep_params["i"]
+    pj, j, tablej = dep_params["j"]
+
+    def f(vx):
+        return vx ** 2
+
+    pi.get = lambda: f(px())
+
+    def g(vx, vy):
+        return vx ** 2 + vy ** 2
+
+    pj.get = lambda: g(px(), py())
+
+    sweep_values_x = [0, 1, 2]
+    sweep_values_y = [4, 5, 6]
+
+    sweep_object = Nest(
+        Sweep(x, tablex, lambda: sweep_values_x),
+        Chain(
+            Measure(i, tablei),
+            Nest(
+                Sweep(y, tabley, lambda: sweep_values_y),
+                Measure(j, tablej)
+            )
+        )
+    )
+
+    meas = SweepMeasurement()
+    meas.register_sweep(sweep_object)
+
+    interdeps = meas._interdeps
+    assert interdeps.dependencies == {
+        ParamSpecBase('i', 'numeric', '', ''): (ParamSpecBase('x', 'numeric', '', ''),),
+        ParamSpecBase('j', 'numeric', '', ''): (ParamSpecBase('x', 'numeric', '', ''),
+                                                ParamSpecBase('y', 'numeric', '', ''))}
+    assert interdeps.inferences == {}
+    assert interdeps.standalones == set()
+
+
+def test_nest_in_chain_2_whatever(indep_params, dep_params):
+    px, x, tablex = indep_params["x"]
+    pi, i, tablei = dep_params["i"]
+    pj, j, tablej = dep_params["j"]
+
+    sweep_values = [0, 1, 2]
+
+    sweep_object = Nest(
+        Sweep(x, tablex, lambda: sweep_values),
+        Chain(
+            Measure(i, tablei)
+        )
+    )
+
+    meas = SweepMeasurement()
+    meas.register_sweep(sweep_object)
+
+    interdeps = meas._interdeps
+    assert interdeps.dependencies == {
+        ParamSpecBase('i', 'numeric', '', ''): (ParamSpecBase('x', 'numeric', '', ''),)}
+    assert interdeps.inferences == {}
+    assert interdeps.standalones == set()


### PR DESCRIPTION
... also port ParamSpec into sweep from QCoDeS so that its deprecation does not impact sweep.

also vast gitignore improvements.