### PR TITLE
Remove ParamSpecBase notion from sweep

### DIFF
--- a/pytopo/sweep/param_spec.py
+++ b/pytopo/sweep/param_spec.py
@@ -2,7 +2,10 @@
 This module is taken from QCoDeS and contains old ParamSpec class
 (here renamed to QcodesParamSpec) that is used in sweep framework 
 in ParamTables. QCoDeS will soon deprecate ParamSpec in favor of 
-ParamSpecBase.
+ParamSpecBase. Note that QcodesParamSpec does not have anything
+that is related to ParamSpecBase (for example, base_version method
+has been removed), which allows QcodesParamSpec to be truly
+independent of QCoDeS.
 
 Copy-pasting code is not good, but it allows to future-proof sweep
 framework users with very little effort.
@@ -10,8 +13,6 @@ framework users with very little effort.
 
 from typing import Union, Sequence, List, Dict, Any, Optional
 from copy import deepcopy
-
-from qcodes.dataset.param_spec import ParamSpecBase
 
 
 class QcodesParamSpec():
@@ -156,16 +157,6 @@ class QcodesParamSpec():
         output['depends_on'] = self._depends_on
 
         return output
-
-    def base_version(self) -> ParamSpecBase:
-        """
-        Return a ParamSpecBase object with the same name, paramtype, label
-        and unit as this QcodesParamSpec
-        """
-        return ParamSpecBase(name=self.name,
-                             paramtype=self.type,
-                             label=self.label,
-                             unit=self.unit)
 
     @classmethod
     def deserialize(cls, ser: Dict[str, Any]) -> 'QcodesParamSpec':

--- a/pytopo/sweep/tests/test_paramspec.py
+++ b/pytopo/sweep/tests/test_paramspec.py
@@ -6,8 +6,6 @@ from numpy import ndarray
 from hypothesis import given, assume
 import hypothesis.strategies as hst
 
-from qcodes.dataset.param_spec import ParamSpecBase
-
 from ..param_spec import QcodesParamSpec as ParamSpec
 
 
@@ -287,17 +285,3 @@ def test_hash_with_deferred_and_inferred_as_paramspecs(
     else:
         assert p1_h != p2_h
         assert 2 == len(p_set)
-
-
-@given(paramspecs=hst.lists(valid_paramspec_kwargs, min_size=1, max_size=1))
-def test_base_version(paramspecs):
-
-    kwargs = paramspecs[0]
-
-    ps = ParamSpec(**kwargs)
-    ps_base = ParamSpecBase(name=kwargs['name'],
-                            paramtype=kwargs['paramtype'],
-                            label=kwargs['label'],
-                            unit=kwargs['unit'])
-
-    assert ps.base_version() == ps_base


### PR DESCRIPTION
Recently ParamSpecBase class was moved in qcodes to a different file/module.
This was not accounted for here. Hence a user had an import problem because
ParamSpecBase in newer qcodes (0.4.0) is in a different module that it was before.

Then, because ParamSpecBase is actually not used at all by sweep, this commit
also completely removes it, and with that the dependency on ParamSpecBase
is completely gone.