### PR TITLE
Alazar acquisition controller: average postdemod & making raw compatible with 9870

### DIFF
--- a/pytopo/rf/alazar/acquisition_controllers.py
+++ b/pytopo/rf/alazar/acquisition_controllers.py
@@ -31,16 +31,15 @@ def rescale_8bit(out, data, n_bits, scale0, scale1):
 
 @nb.jit(nb.void(nb.float32[:], nb.uint8[:], nb.int64, nb.float32, nb.float32), nopython=True, cache=True)
 def _rescale_8bit(out, data, n_bits, scale0, scale1):
-    shift_by = 8 - n_bits
     two_by_n = 1 / (2.0 ** (n_bits - 1))
     prefactor0 = scale0 * two_by_n
     prefactor1 = scale1 * two_by_n
     # Rely on Numba JITing loops.
     for idx_datum in range(len(data)):
         if idx_datum % 2 == 0:
-            scaled = prefactor0 * nb.float32(np.right_shift(data[idx_datum], shift_by)) - scale0
+            scaled = prefactor0 * nb.float32(data[idx_datum]) - scale0
         else:
-            scaled = prefactor1 * nb.float32(np.right_shift(data[idx_datum], shift_by)) - scale1
+            scaled = prefactor1 * nb.float32(data[idx_datum]) - scale1
         out[idx_datum] = scaled
 
 # @nb.vectorize([


### PR DESCRIPTION
I added two changes to rf.alazar.acquisition_controllers, which in hindsight should probably be two different pull requests?

The first is to add the option for averaging your alazar data post demodulation to PostDemodCtl. Right now you can only average before demodulation, which is faster, but puts precise timing constraints on your measurements. These are not always met, in which case you can only average your buffers together post demodulation. 

The second is a bugfix for the RawAcqCtl, which uses a utility function 'rescale'. Even though RawAcqCtl has a paramter nbits that stores the number of bits of the Alazar card uses, 'rescale' hardcodes the datatype returned by the alazar to be nb.uint16 inside the decorator of '_rescale'.

For now I made a rather stupid fix to this, by defining another function, rescale_8bit. That is because I could not figure out how to make the decorator of _rescale depend on an input parameter. If someone can point out how to do so, we can keep just a single rescaling function rather than adding a second one. 

Neither changes should break anything for existing users; the post_demod averaging is False by default, and the RawAcqCtl is currently already broken for anyone not using the 12 bit Alazar card.